### PR TITLE
feat: add database-aware json type helper

### DIFF
--- a/src/brussels/__tests__/types/test_json_type.py
+++ b/src/brussels/__tests__/types/test_json_type.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from sqlalchemy import JSON
+from sqlalchemy.dialects.postgresql import dialect as postgres_dialect
+from sqlalchemy.dialects.sqlite import dialect as sqlite_dialect
+
+from brussels.types import Json
+
+
+def test_sqlite_variant_is_json() -> None:
+    sqlite_type = Json.with_variant(JSON(), "sqlite")
+    assert isinstance(sqlite_type, JSON)
+
+
+def test_postgres_variant_is_jsonb() -> None:
+    compiled = Json.compile(dialect=postgres_dialect())
+    assert "JSONB" in compiled
+
+
+def test_sqlite_compile_uses_json() -> None:
+    compiled = Json.compile(dialect=sqlite_dialect())
+    assert "JSON" in compiled

--- a/src/brussels/types/__init__.py
+++ b/src/brussels/types/__init__.py
@@ -1,3 +1,4 @@
 from .datetime_utc import DateTimeUTC
+from .json_type import Json
 
-__all__ = ["DateTimeUTC"]
+__all__ = ["DateTimeUTC", "Json"]

--- a/src/brussels/types/json_type.py
+++ b/src/brussels/types/json_type.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from typing import Final
+
+from sqlalchemy import JSON
+from sqlalchemy.dialects.postgresql import JSONB
+
+Json: Final[JSON] = JSON().with_variant(JSONB(), "postgresql")


### PR DESCRIPTION
## Summary
- introduce `Json` type in `brussels.types` that defaults to SQLAlchemy JSON and switches to JSONB for PostgreSQL
- export the new type through `src/brussels/types/__init__.py`
- add unit tests that verify the SQLite and PostgreSQL variants compile to the expected SQL types

## Testing
- Not run (not requested)