### PR TITLE
feat: add acronym-aware auto tablename generation

### DIFF
--- a/src/brussels/__tests__/test_base.py
+++ b/src/brussels/__tests__/test_base.py
@@ -111,8 +111,8 @@ def test_dataclass_base_uses_base_metadata() -> None:
 
 def test_base_handles_acronyms_and_digits() -> None:
     assert OAuthToken.__tablename__ == "oauth_token"
-    assert JSON2XML.__tablename__ == "json2_xml"
-    assert My2FAThing.__tablename__ == "my2_fa_thing"
+    assert JSON2XML.__tablename__ == "json_2xml"
+    assert My2FAThing.__tablename__ == "my_2fa_thing"
 
 
 def test_base_allows_explicit_tablename_override() -> None:

--- a/src/brussels/base.py
+++ b/src/brussels/base.py
@@ -19,8 +19,9 @@ TYPE_ANNOTATION_MAP: Final[dict[type | Any, object]] = {
     datetime: DateTimeUTC,
 }
 
-TABLENAME_CAPITAL_RUN_PATTERN: Final = re.compile(r"(?<=[A-Z]{2})([A-Z][a-z])")
-TABLENAME_BOUNDARY_PATTERN: Final = re.compile(r"(?<=[a-z0-9])([A-Z])")
+TABLENAME_CAPITAL_RUN_PATTERN: Final[re.Pattern] = re.compile(r"(?<=[A-Z]{2})([A-Z][a-z])")
+TABLENAME_LOWER_UPPER_PATTERN: Final[re.Pattern] = re.compile(r"(?<=[a-z])([A-Z])")
+TABLENAME_ALPHA_DIGIT_PATTERN: Final[re.Pattern] = re.compile(r"(?<=[A-Za-z])([0-9])")
 
 
 class Base(DeclarativeBase):
@@ -31,7 +32,8 @@ class Base(DeclarativeBase):
     @declared_attr.directive
     def __tablename__(self) -> str:
         name = TABLENAME_CAPITAL_RUN_PATTERN.sub(r"_\1", self.__name__)
-        return TABLENAME_BOUNDARY_PATTERN.sub(r"_\1", name).lower()
+        name = TABLENAME_LOWER_UPPER_PATTERN.sub(r"_\1", name)
+        return TABLENAME_ALPHA_DIGIT_PATTERN.sub(r"_\1", name).lower()
 
 
 class DataclassBase(MappedAsDataclass, Base):


### PR DESCRIPTION
## Summary
- define a regex-driven `Base.__tablename__` declared attribute that converts class names to lower snake case while treating adjacent capitals as a single segment
- update the Base test helpers to rely on the automatic naming, adjust constraint expectations, and add acronym/digit boundary + override tests for new behavior

## Testing
- Not run (not requested)