### PR TITLE
feat: use stdlib uuid7 for uuidv7 primary keys on python 3.14+

### DIFF
--- a/src/brussels/__tests__/mixins/test_primary_key_mixin.py
+++ b/src/brussels/__tests__/mixins/test_primary_key_mixin.py
@@ -1,5 +1,7 @@
 import inspect
 from collections.abc import Iterator
+from dataclasses import fields
+from sys import version_info
 from typing import Any, cast
 from uuid import UUID, uuid4
 
@@ -81,6 +83,10 @@ def test_uuidv7_id_column_definition() -> None:
     compiled_server_default = cast("Any", server_default).arg.compile(dialect=postgresql.dialect())
     assert "uuidv7" in str(compiled_server_default)
 
+    if version_info >= (3, 14):
+        field_map = {field.name: field for field in fields(UUIDv7Widget)}
+        assert field_map["id"].default_factory.__name__ == "uuid7"
+
 
 def test_uuidv7_id_not_in_init_signature() -> None:
     signature = inspect.signature(UUIDv7Widget)
@@ -91,10 +97,14 @@ def test_uuidv7_id_not_in_init_signature() -> None:
         widget_cls(id=uuid4(), name="widget")
 
 
-def test_uuidv7_id_is_not_populated_before_flush() -> None:
+def test_uuidv7_id_default_matches_runtime() -> None:
     widget = UUIDv7Widget(name="widget")
 
-    assert widget.id is None
+    if version_info >= (3, 14):
+        assert isinstance(widget.id, UUID)
+        assert widget.id.version == 7
+    else:
+        assert widget.id is None
 
 
 def test_uuidv7_models_satisfy_primary_key_mixin_contract() -> None:

--- a/src/brussels/__tests__/types/file/test_file.py
+++ b/src/brussels/__tests__/types/file/test_file.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from sys import version_info
 from typing import TYPE_CHECKING, cast
 from uuid import UUID, uuid4
 
@@ -163,15 +164,19 @@ def test_put_sync_flush_populates_uuidv7_id_before_key_generation(
 
     with Session(engine) as session:
         model = UUIDv7FileModel()
+        if version_info >= (3, 14):
+            assert isinstance(model.id, UUID)
+            assert model.id.version == 7
+        else:
+            assert model.id is None
         session.add(model)
-        assigned_id = uuid4()
         flush_calls = 0
 
         def fake_flush() -> None:
             nonlocal flush_calls
             flush_calls += 1
-            if model.id is None:
-                model.id = assigned_id
+            if version_info < (3, 14) and model.id is None:
+                model.id = uuid4()
 
         monkeypatch.setattr(session, "flush", fake_flush)
 
@@ -183,10 +188,14 @@ def test_put_sync_flush_populates_uuidv7_id_before_key_generation(
         )
 
         assert put_result == {"e_tag": None, "version": None}
-        assert flush_calls == 2
-        assert model.id == assigned_id
+        assert flush_calls == (1 if version_info >= (3, 14) else 2)
+        assert isinstance(model.id, UUID)
+        if version_info >= (3, 14):
+            assert model.id.version == 7
+        else:
+            assert model.id.version == 4
         assert model.file is not None
-        assert model.file.key == f"{assigned_id}/file"
+        assert model.file.key == f"{model.id}/file"
         assert model.file.status == "pending"
         assert store_ops.calls == []
 
@@ -199,15 +208,32 @@ def test_put_sync_rejects_uuidv7_model_without_flush(engine: Engine) -> None:
         model = UUIDv7FileModel()
         session.add(model)
 
-        with pytest.raises(ValueError, match=r"Pass flush=True or flush the model before calling put"):
-            _uuidv7_file_handle(model).put(
+        if version_info >= (3, 14):
+            assert isinstance(model.id, UUID)
+            assert model.id.version == 7
+
+            put_result = _uuidv7_file_handle(model).put(
                 b"hello",
                 content_type="text/plain",
                 session=session,
+                flush=False,
             )
 
-        assert model.file is None
-        assert store_ops.calls == []
+            assert put_result == {"e_tag": None, "version": None}
+            assert model.file is not None
+            assert model.file.key == f"{model.id}/file"
+            assert model.file.status == "pending"
+            assert store_ops.calls == []
+        else:
+            with pytest.raises(ValueError, match=r"Pass flush=True or flush the model before calling put"):
+                _uuidv7_file_handle(model).put(
+                    b"hello",
+                    content_type="text/plain",
+                    session=session,
+                )
+
+            assert model.file is None
+            assert store_ops.calls == []
 
 
 def test_put_sync_defers_and_commits_when_sqlalchemy_session_is_attached(engine: Engine) -> None:
@@ -353,15 +379,19 @@ async def test_put_async_flush_populates_uuidv7_id_before_key_generation(engine:
 
     with Session(engine) as session:
         model = UUIDv7FileModel()
+        if version_info >= (3, 14):
+            assert isinstance(model.id, UUID)
+            assert model.id.version == 7
+        else:
+            assert model.id is None
         session.add(model)
-        assigned_id = uuid4()
         flush_calls = 0
 
         def on_flush() -> None:
             nonlocal flush_calls
             flush_calls += 1
-            if model.id is None:
-                model.id = assigned_id
+            if version_info < (3, 14) and model.id is None:
+                model.id = uuid4()
 
         await _uuidv7_file_handle(model).put_async(
             b"data",
@@ -370,10 +400,14 @@ async def test_put_async_flush_populates_uuidv7_id_before_key_generation(engine:
             flush=True,
         )
 
-        assert flush_calls == 2
-        assert model.id == assigned_id
+        assert flush_calls == (1 if version_info >= (3, 14) else 2)
+        assert isinstance(model.id, UUID)
+        if version_info >= (3, 14):
+            assert model.id.version == 7
+        else:
+            assert model.id.version == 4
         assert model.file is not None
-        assert model.file.key == f"{assigned_id}/file"
+        assert model.file.key == f"{model.id}/file"
         assert model.file.status == "pending"
         assert store_ops.calls == []
 
@@ -387,15 +421,32 @@ async def test_put_async_rejects_uuidv7_model_without_flush(engine: Engine) -> N
         model = UUIDv7FileModel()
         session.add(model)
 
-        with pytest.raises(ValueError, match=r"Pass flush=True or flush the model before calling put_async"):
-            await _uuidv7_file_handle(model).put_async(
+        if version_info >= (3, 14):
+            assert isinstance(model.id, UUID)
+            assert model.id.version == 7
+
+            put_result = await _uuidv7_file_handle(model).put_async(
                 b"data",
                 content_type="text/plain",
-                session=session,
+                session=cast("AsyncSession", AsyncSessionShim(session)),
+                flush=False,
             )
 
-        assert model.file is None
-        assert store_ops.calls == []
+            assert put_result == {"e_tag": None, "version": None}
+            assert model.file is not None
+            assert model.file.key == f"{model.id}/file"
+            assert model.file.status == "pending"
+            assert store_ops.calls == []
+        else:
+            with pytest.raises(ValueError, match=r"Pass flush=True or flush the model before calling put_async"):
+                await _uuidv7_file_handle(model).put_async(
+                    b"data",
+                    content_type="text/plain",
+                    session=session,
+                )
+
+            assert model.file is None
+            assert store_ops.calls == []
 
 
 @pytest.mark.asyncio

--- a/src/brussels/mixins/primary_key.py
+++ b/src/brussels/mixins/primary_key.py
@@ -1,7 +1,11 @@
+from sys import version_info
 from uuid import UUID, uuid4
 
 from sqlalchemy import func
 from sqlalchemy.orm import Mapped, MappedAsDataclass, declarative_mixin, mapped_column
+
+if version_info >= (3, 14):
+    from uuid import uuid7
 
 
 @declarative_mixin
@@ -34,28 +38,53 @@ class PrimaryKeyMixin(MappedAsDataclass):
     )
 
 
-@declarative_mixin
-class UUIDv7PrimaryKeyMixin(PrimaryKeyMixin):
-    """Mixin that adds a PostgreSQL 18+ UUIDv7 primary key column.
+if version_info >= (3, 14):
 
-    Extends PrimaryKeyMixin so models continue to satisfy APIs that require the
-    existing primary-key mixin contract. The id field is excluded from __init__
-    (init=False) and is generated during insert using PostgreSQL's uuidv7()
-    function. Because the UUID is database generated, ID-derived workflows
-    require the row to be flushed or already persisted.
+    @declarative_mixin
+    class UUIDv7PrimaryKeyMixin(PrimaryKeyMixin):
+        """Mixin that adds a UUIDv7 primary key column.
 
-    Usage:
-        class MyModel(DataclassBase, UUIDv7PrimaryKeyMixin, TimestampMixin):
-            __tablename__ = "my_table"
-            name: Mapped[str]
+        On Python 3.14+, new instances get an id from stdlib uuid7()
+        immediately. The column still keeps the PostgreSQL uuidv7() insert and
+        server defaults for database-side fallback.
 
-    This mixin is only supported on PostgreSQL 18+ because it relies on the
-    built-in uuidv7() database function.
-    """
+        Usage:
+            class MyModel(DataclassBase, UUIDv7PrimaryKeyMixin, TimestampMixin):
+                __tablename__ = "my_table"
+                name: Mapped[str]
+        """
 
-    id: Mapped[UUID] = mapped_column(
-        primary_key=True,
-        insert_default=func.uuidv7(),
-        server_default=func.uuidv7(),
-        init=False,
-    )
+        id: Mapped[UUID] = mapped_column(
+            primary_key=True,
+            default_factory=uuid7,
+            insert_default=func.uuidv7(),
+            server_default=func.uuidv7(),
+            init=False,
+        )
+else:
+
+    @declarative_mixin
+    class UUIDv7PrimaryKeyMixin(PrimaryKeyMixin):
+        """Mixin that adds a PostgreSQL 18+ UUIDv7 primary key column.
+
+        Extends PrimaryKeyMixin so models continue to satisfy APIs that require
+        the existing primary-key mixin contract. The id field is excluded from
+        __init__ (init=False) and is generated during insert using PostgreSQL's
+        uuidv7() function. Because the UUID is database generated, ID-derived
+        workflows require the row to be flushed or already persisted.
+
+        Usage:
+            class MyModel(DataclassBase, UUIDv7PrimaryKeyMixin, TimestampMixin):
+                __tablename__ = "my_table"
+                name: Mapped[str]
+
+        This mixin is only supported on PostgreSQL 18+ because it relies on the
+        built-in uuidv7() database function.
+        """
+
+        id: Mapped[UUID] = mapped_column(
+            primary_key=True,
+            insert_default=func.uuidv7(),
+            server_default=func.uuidv7(),
+            init=False,
+        )


### PR DESCRIPTION
## Summary
- Use `uuid.uuid7()` for `UUIDv7PrimaryKeyMixin` on Python 3.14+ so UUIDv7 ids exist at construction time.
- Keep the PostgreSQL `uuidv7()` insert/server defaults in place for database-side fallback.
- Preserve the older flush-required behavior on Python 3.12/3.13.
- Update mixin and file-storage tests to cover both runtime paths.

## Testing
- `uv run --active pytest`
- `uv run --active prek run --all-files`